### PR TITLE
Update to react-router 0.13.1, using this.context.router

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/mtscout6/react-router-bootstrap",
   "peerDependencies": {
     "react-bootstrap": ">=0.15",
-    "react-router": ">=0.5.1"
+    "react-router": ">=0.13.1"
   },
   "devDependencies": {
     "bootstrap": "^3.3.1",
@@ -52,7 +52,7 @@
     "phantomjs": "^1.9.13",
     "react": "*",
     "react-bootstrap": ">=0.15",
-    "react-router": ">=0.5.1",
+    "react-router": ">=0.13.1",
     "react-tools": "^0.12.1",
     "style-loader": "^0.8.2",
     "url-loader": "^0.5.5",

--- a/src/ButtonLink.js
+++ b/src/ButtonLink.js
@@ -1,15 +1,15 @@
 var React = require('react');
 
 var Button = require('react-bootstrap/lib/Button');
-var { Navigation, State } = require('react-router');
 var LinkMixin = require('./LinkMixin');
 
 var ButtonLink = React.createClass({
   mixins: [
-    LinkMixin,
-    Navigation,
-    State
+    LinkMixin
   ],
+  contextTypes: {
+    router: React.PropTypes.func.isRequired
+  },
 
   render: function () {
     var {
@@ -20,7 +20,7 @@ var ButtonLink = React.createClass({
       ...props} = this.props;
 
     if (this.props.active === undefined) {
-      active = this.isActive(to, params, query);
+      active = this.context.router.isActive(to, params, query);
     }
 
     return (

--- a/src/LinkMixin.js
+++ b/src/LinkMixin.js
@@ -17,6 +17,10 @@ module.exports = {
     query: React.PropTypes.object,
     onClick: React.PropTypes.func
   },
+  contextTypes: {
+    router: React.PropTypes.func.isRequired
+  },
+
 
   getDefaultProps: function () {
     return {
@@ -28,7 +32,7 @@ module.exports = {
    * Returns the value of the "href" attribute to use on the DOM element.
    */
   getHref: function () {
-    return this.makeHref(this.props.to, this.props.params, this.props.query);
+    return this.context.router.makeHref(this.props.to, this.props.params, this.props.query);
   },
 
   /**
@@ -42,7 +46,7 @@ module.exports = {
       classNames[this.props.className] = true;
     }
 
-    if (this.isActive(this.props.to, this.props.params, this.props.query)) {
+    if (this.context.router.isActive(this.props.to, this.props.params, this.props.query)) {
       classNames[this.props.activeClassName] = true;
     }
 
@@ -68,7 +72,7 @@ module.exports = {
     event.preventDefault();
 
     if (allowTransition) {
-      this.transitionTo(this.props.to, this.props.params, this.props.query);
+      this.context.router.transitionTo(this.props.to, this.props.params, this.props.query);
     }
   }
 };

--- a/src/MenuItemLink.js
+++ b/src/MenuItemLink.js
@@ -2,17 +2,17 @@ var React = require('react');
 var classSet = require('react/lib/cx');
 
 var MenuItem = require('react-bootstrap/lib/MenuItem');
-var { Navigation, State } = require('react-router');
 var LinkMixin = require('./LinkMixin');
 
 var joinClasses = require('react/lib/joinClasses');
 
 var MenuItemLink = React.createClass({
   mixins: [
-    LinkMixin,
-    Navigation,
-    State
+    LinkMixin
   ],
+  contextTypes: {
+    router: React.PropTypes.func.isRequired
+  },
 
   render: function() {
     var {
@@ -25,7 +25,7 @@ var MenuItemLink = React.createClass({
       ...props} = this.props;
 
     if (this.props.active === undefined) {
-      active = this.isActive(to, params, query);
+      active = this.context.router.isActive(to, params, query);
     }
 
     return (

--- a/src/NavItemLink.js
+++ b/src/NavItemLink.js
@@ -1,15 +1,15 @@
 var React = require('react');
 
 var NavItem = require('react-bootstrap/lib/NavItem');
-var { Navigation, State } = require('react-router');
 var LinkMixin = require('./LinkMixin');
 
 var NavItemLink = React.createClass({
   mixins: [
-    LinkMixin,
-    Navigation,
-    State
+    LinkMixin
   ],
+  contextTypes: {
+    router: React.PropTypes.func.isRequired
+  },
 
   render: function() {
     var {
@@ -20,7 +20,7 @@ var NavItemLink = React.createClass({
       ...props} = this.props;
 
     if (this.props.active === undefined) {
-      active = this.isActive(to, params, query);
+      active = this.context.router.isActive(to, params, query);
     }
 
     return (


### PR DESCRIPTION
React router 0.13.x uses the context object instead of mixins.
This commit addresses this change and fixes the deprecation warnings that react-router issues.